### PR TITLE
Dirty fixes that make it work on Mac OS X

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
-
+LIBS=-lintl
 CC?=gcc
 
 # Run this with make LIBS=-lrt if you want to compile on kfreebsd
 
-all: macping mndp mactelnet mactelnetd
+all: macping mndp mactelnet
 
 clean: distclean
 
@@ -15,18 +15,14 @@ distclean:
 dist: distclean po
 
 install: all install-docs
-	install -d $(DESTDIR)/usr/bin
-	install mndp $(DESTDIR)/usr/bin/
-	install macping $(DESTDIR)/usr/bin/
-	install mactelnet $(DESTDIR)/usr/bin/
-	install -d $(DESTDIR)/usr/sbin
-	install -o root mactelnetd $(DESTDIR)/usr/sbin/
-	install -d $(DESTDIR)/etc
-	install -m 600 -o root config/mactelnetd.users $(DESTDIR)/etc/
+	install -d $(PREFIX)/bin/
+	install mndp $(PREFIX)/bin/
+	install macping $(PREFIX)/bin/
+	install mactelnet $(PREFIX)/bin/
 
 install-docs:
-	install -d $(DESTDIR)/usr/share/man/man1/
-	install docs/*.1 $(DESTDIR)/usr/share/man/man1/
+	install -d $(PREFIX)/share/man/man1/
+	install docs/*.1 $(PREFIX)/share/man/man1/
 
 po: po/mactelnet.pot
 

--- a/interfaces.c
+++ b/interfaces.c
@@ -26,8 +26,7 @@
 #include <sys/types.h>
 #include <ifaddrs.h>
 #include <netinet/ip.h>
-#include <netinet/udp.h>
-#include <netinet/ether.h>
+#include <net/ethernet.h>
 #include <arpa/inet.h>
 #include <net/if.h>
 #include <sys/ioctl.h>

--- a/interfaces.h
+++ b/interfaces.h
@@ -19,6 +19,42 @@
 #ifndef _INTERFACES_H
 #define _INTERFACES_H 1
 
+#include <stdint.h>
+
+#define ETH_FRAME_LEN   1514
+#define ETH_P_IP	0x0800		/* Internet Protocol packet	*/
+#define ETH_ALEN        6               /* Octets in one ethernet addr   */
+#define IPV4_ALEN 4
+
+struct iphdr {
+  /* xxx: assumes little-endian */
+  uint8_t   ihl:4,
+            version:4;
+  uint8_t   tos;
+  uint16_t  tot_len;
+  uint16_t  id;
+  uint16_t  frag_off;
+  uint8_t   ttl;
+  uint8_t   protocol;
+  uint16_t  check;
+  uint32_t  saddr;
+  uint32_t  daddr;
+};
+
+struct udphdr {
+  uint16_t  source;
+  uint16_t  dest;
+  uint16_t  len;
+  uint16_t check;
+};
+
+
+struct ethhdr {
+	unsigned char	h_dest[ETH_ALEN];
+	unsigned char	h_source[ETH_ALEN];
+	unsigned short	h_proto;
+} __attribute__((packed));
+
 #define MAX_INTERFACES 32
 
 struct net_interface {

--- a/macping.c
+++ b/macping.c
@@ -22,7 +22,7 @@
 #include <signal.h>
 #include <stdio.h>
 #include <arpa/inet.h>
-#include <netinet/ether.h>
+#include <net/ethernet.h>
 #include <string.h>
 #include <time.h>
 #include <sys/time.h>

--- a/mactelnet.c
+++ b/mactelnet.c
@@ -26,10 +26,10 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <signal.h>
-#include <endian.h>
+#include <machine/endian.h>
 #include <arpa/inet.h>
 #include <netinet/in.h>
-#include <netinet/ether.h>
+#include <net/ethernet.h>
 #include <sys/time.h>
 #include <time.h>
 #include <sys/types.h>
@@ -47,6 +47,9 @@
 #include "mndp.h"
 
 #define PROGRAM_NAME "MAC-Telnet"
+
+#include <libkern/OSByteOrder.h>
+#define htole16(x) OSSwapHostToLittleInt16(x)
 
 #define _(String) gettext (String)
 

--- a/mactelnetd.c
+++ b/mactelnetd.c
@@ -26,12 +26,12 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <signal.h>
-#include <endian.h>
+#include <machine/endian.h>
 #include <time.h>
 #include <arpa/inet.h>
 #include <net/ethernet.h>
 #include <netinet/in.h>
-#include <netinet/ether.h>
+#include <net/ethernet.h>
 #include <sys/time.h>
 #include <time.h>
 #include <sys/types.h>
@@ -44,7 +44,6 @@
 #endif
 #include <sys/ioctl.h>
 #include <sys/stat.h>
-#include <sys/sysinfo.h>
 #include <pwd.h>
 #include <utmp.h>
 #include <syslog.h>

--- a/mndp.c
+++ b/mndp.c
@@ -21,7 +21,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <arpa/inet.h>
-#include <netinet/ether.h>
+#include <net/ethernet.h>
 #include <string.h>
 #include "protocol.h"
 #include "config.h"

--- a/protocol.c
+++ b/protocol.c
@@ -28,13 +28,76 @@
 #endif
 #include <arpa/inet.h>
 #include <netinet/in.h>
-#include <netinet/ether.h>
+#include <net/ethernet.h>
 #include <time.h>
-#include <endian.h>
 #include "protocol.h"
 #include "config.h"
+#include <ctype.h>
+
+#include <libkern/OSByteOrder.h>
+#define le32toh(x) OSSwapLittleToHostInt32(x)
 
 #define _(String) gettext (String)
+
+// lifted from glibc:
+
+/* Copyright (C) 1996,97,98,99,2002 Free Software Foundation, Inc.
+   This file is part of the GNU C Library.
+   Contributed by Ulrich Drepper <drepper@cygnus.com>, 1996.
+
+   The GNU C Library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 2.1 of the License, or (at your option) any later version.
+
+   The GNU C Library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with the GNU C Library; if not, write to the Free
+   Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+   02111-1307 USA.  */
+
+struct ether_addr *
+ether_aton_r (const char *asc, struct ether_addr *addr)
+{
+  size_t cnt;
+
+  for (cnt = 0; cnt < 6; ++cnt)
+    {
+      unsigned int number;
+      char ch;
+
+      ch = _tolower (*asc++);
+      if ((ch < '0' || ch > '9') && (ch < 'a' || ch > 'f'))
+	return NULL;
+      number = isdigit (ch) ? (ch - '0') : (ch - 'a' + 10);
+
+      ch = _tolower (*asc);
+      if ((cnt < 5 && ch != ':') || (cnt == 5 && ch != '\0' && !isspace (ch)))
+	{
+	  ++asc;
+	  if ((ch < '0' || ch > '9') && (ch < 'a' || ch > 'f'))
+	    return NULL;
+	  number <<= 4;
+	  number += isdigit (ch) ? (ch - '0') : (ch - 'a' + 10);
+
+	  ch = *asc;
+	  if (cnt < 5 && ch != ':')
+	    return NULL;
+	}
+
+      /* Store result.  */
+      addr->ether_addr_octet[cnt] = (unsigned char) number;
+
+      /* Skip ':'.  */
+      ++asc;
+    }
+
+  return addr;
+}
 
 int init_packet(struct mt_packet *packet, enum mt_ptype ptype, unsigned char *srcmac, unsigned char *dstmac, unsigned short sessionkey, unsigned int counter) {
 	unsigned char *data = packet->data;


### PR DESCRIPTION
As I mentioned in #13, there's various problems in the way of making these tools build on Mac OS X. I was on-site with a broken router and needed `mactelnet` on my Mac, so I developed this patch in a hurry.

This patch isn't suitable for merging, because:

* It probably breaks the build on every other platform.
* It doesn't build `mactelnetd`, which I didn't need and which seems to have other issues.
* It lifts `ether_aton_r` straight from glibc and into `protocol.c`. (Hey, at least the LGPL is GPL-compatible!)
* It's based on v0.4.0 and doesn't apply cleanly to master.
* Its `struct iphdr` layout assumes we're little-endian.

This patch does, however, *work*.