### PR TITLE
Changes to build all tools on OS X

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
 
 CC?=gcc
 
+# Run this with make LIBS=-lrt if you want to compile on kfreebsd
+# Run this with make LIBS=-lintl if you want to compile on OS X
+
 all: macping mndp mactelnet mactelnetd
 
 clean: distclean
@@ -55,7 +58,7 @@ mactelnet: config.h mactelnet.c mactelnet.h protocol.o console.o interfaces.o md
 	${CC} -Wall ${CFLAGS} ${LDFLAGS} -o mactelnet mactelnet.c protocol.o console.o interfaces.o md5.o autologin.o -DFROM_MACTELNET mndp.c ${LIBS}
 
 mactelnetd: config.h mactelnetd.c protocol.o interfaces.o console.o users.o users.h md5.o
-	${CC} -Wall ${CFLAGS} ${LDFLAGS} -o mactelnetd mactelnetd.c protocol.o console.o interfaces.o users.o md5.o -lrt ${LIBS}
+	${CC} -Wall ${CFLAGS} ${LDFLAGS} -o mactelnetd mactelnetd.c protocol.o console.o interfaces.o users.o md5.o ${LIBS}
 
 mndp: config.h mndp.c protocol.o
 	${CC} -Wall ${CFLAGS} ${LDFLAGS} -o mndp mndp.c protocol.o ${LIBS}

--- a/interfaces.c
+++ b/interfaces.c
@@ -29,12 +29,12 @@
 #include <sys/socket.h>
 #include <sys/types.h>
 #include <ifaddrs.h>
-#if defined(__FreeBSD__)
+#if defined(__FreeBSD__) || defined(__APPLE__)
 #include <netinet/in.h>
 #endif
 #include <netinet/ip.h>
 #include <netinet/udp.h>
-#if defined(__FreeBSD__)
+#if defined(__FreeBSD__) || defined(__APPLE__)
 #include <net/ethernet.h>
 #define ETH_FRAME_LEN (ETHER_MAX_LEN - ETHER_CRC_LEN)
 #define ETH_ALEN ETHER_ADDR_LEN
@@ -298,7 +298,7 @@ int net_send_udp(const int fd, struct net_interface *interface, const unsigned c
 	*/
 	static unsigned char stackbuf[ETH_FRAME_LEN];
 	void* buffer = (void*)&stackbuf;
-#if defined(__FreeBSD__)
+#if defined(__FreeBSD__) || defined(__APPLE__)
 	struct ether_header *eh = (struct ether_header *)buffer;
 	struct ip *ip = (struct ip *)(buffer + 14);
 #else
@@ -324,7 +324,7 @@ int net_send_udp(const int fd, struct net_interface *interface, const unsigned c
 	}
 
 	/* Init ethernet header */
-#if defined(__FreeBSD__)
+#if defined(__FreeBSD__) || defined(__APPLE__)
 	memcpy(eh->ether_shost, sourcemac, ETH_ALEN);
 	memcpy(eh->ether_dhost, destmac, ETH_ALEN);
 	eh->ether_type = htons(ETHERTYPE_IP);
@@ -349,7 +349,7 @@ int net_send_udp(const int fd, struct net_interface *interface, const unsigned c
 #endif
 
 	/* Init IP Header */
-#if defined(__FreeBSD__)
+#if defined(__FreeBSD__) || defined(__APPLE__)
 	ip->ip_v = 4;
 	ip->ip_hl = 5;
 	ip->ip_tos = 0x10;
@@ -376,14 +376,14 @@ int net_send_udp(const int fd, struct net_interface *interface, const unsigned c
 #endif
 
 	/* Calculate checksum for IP header */
-#if defined(__FreeBSD__)
+#if defined(__FreeBSD__) || defined(__APPLE__)
 	ip->ip_sum = in_cksum((unsigned short *)ip, sizeof(struct ip));
 #else
 	ip->check = in_cksum((unsigned short *)ip, sizeof(struct iphdr));
 #endif
 
 	/* Init UDP Header */
-#if defined(__FreeBSD__)
+#if defined(__FreeBSD__) || defined(__APPLE__)
 	udp->uh_sport = htons(sourceport);
 	udp->uh_dport = htons(destport);
 	udp->uh_ulen = htons(sizeof(struct udphdr) + datalen);
@@ -399,7 +399,7 @@ int net_send_udp(const int fd, struct net_interface *interface, const unsigned c
 	memcpy(rest, data, datalen);
 
 	/* Add UDP checksum */
-#if defined(__FreeBSD__)
+#if defined(__FreeBSD__) || defined(__APPLE__)
 	udp->uh_sum = udp_sum_calc((unsigned char *)&(ip->ip_src.s_addr),
 	  (unsigned char *)&(ip->ip_dst.s_addr),
 	  (unsigned char *)udp,

--- a/macping.c
+++ b/macping.c
@@ -22,7 +22,7 @@
 #include <signal.h>
 #include <stdio.h>
 #include <arpa/inet.h>
-#if defined(__FreeBSD__)
+#if defined(__FreeBSD__) || defined(__APPLE__)
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <net/ethernet.h>

--- a/mactelnet.c
+++ b/mactelnet.c
@@ -26,12 +26,18 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <signal.h>
-#if defined(__FreeBSD__)
+#if defined(__APPLE__)
+# include <libkern/OSByteOrder.h>
+# define htole16 OSSwapHostToLittleInt16
+#elif defined(__FreeBSD__)
 #include <sys/endian.h>
+#else
+#include <endian.h>
+#endif
+#if defined(__FreeBSD__) || defined(__APPLE__)
 #include <sys/types.h>
 #include <net/ethernet.h>
 #else
-#include <endian.h>
 #include <netinet/ether.h>
 #endif
 #include <arpa/inet.h>

--- a/mndp.c
+++ b/mndp.c
@@ -23,7 +23,7 @@
 #include <signal.h>
 #include <unistd.h>
 #include <errno.h>
-#if defined(__FreeBSD__)
+#if defined(__FreeBSD__) || defined(__APPLE__)
 #include <net/ethernet.h>
 #include <netinet/in.h>
 #include <sys/socket.h>

--- a/protocol.c
+++ b/protocol.c
@@ -28,7 +28,7 @@
 #endif
 #include <arpa/inet.h>
 #include <netinet/in.h>
-#if defined(__FreeBSD__)
+#if defined(__FreeBSD__) || defined(__APPLE__)
 #include <net/ethernet.h>
 #include <sys/types.h>
 #include <sys/socket.h>
@@ -36,7 +36,10 @@
 #include <netinet/ether.h>
 #endif
 #include <time.h>
-#if defined(__FreeBSD__)
+#if defined(__APPLE__)
+# include <libkern/OSByteOrder.h>
+# define le32toh OSSwapLittleToHostInt32
+#elif defined(__FreeBSD__)
 #include <sys/endian.h>
 #else
 #include <endian.h>
@@ -562,7 +565,12 @@ int query_mndp_or_mac(char *address, unsigned char *dstmac, int verbose) {
 		}
 	} else {
 		/* Convert mac address string to ether_addr struct */
+#if defined(__APPLE__)
+		struct ether_addr* dstmac_buf = ether_aton(address);
+		memcpy(dstmac, dstmac_buf, sizeof(struct ether_addr));
+#else
 		ether_aton_r(address, (struct ether_addr *)dstmac);
+#endif
 	}
 
 	return 1;


### PR DESCRIPTION
I mostly just added __APPLE__ in many of the places where __FreeBSD__ was used.

This requires that the user follow the instructions at the top of the Makefile, since there's no configure script to decide if -lintl or -lrt are needed.