### PR TITLE
Add a Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+FROM alpine AS builder
+
+# Install build dependencies
+RUN apk add --no-cache build-base automake autoconf git gettext gettext-dev linux-headers
+
+# Copy everything to /src
+RUN mkdir /src
+WORKDIR /src
+ADD . /src/
+
+# Build
+ENV CFLAGS="-D_GNU_SOURCE" LIBS="-lintl"
+RUN ./autogen.sh
+RUN ./configure --prefix=/build
+RUN make all install
+
+## 
+FROM alpine
+
+# Install runtime dependencies
+RUN apk add --no-cache gettext-libs
+
+# Copy build artifacts
+COPY --from=builder /build/ /usr/
+
+CMD ["/usr/bin/mactelnet"]

--- a/src/mactelnetd.c
+++ b/src/mactelnetd.c
@@ -16,6 +16,7 @@
     with this program; if not, write to the Free Software Foundation, Inc.,
     51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
+#include <config.h>
 #define _POSIX_C_SOURCE 199309L
 #define _XOPEN_SOURCE 600
 #define _BSD_SOURCE
@@ -37,7 +38,7 @@
 #else
 #include <endian.h>
 #endif
-#if defined(__FreeBSD__) || defined(__APPLE__)
+#if HAVE_PATHS_H
 #include <paths.h>
 #endif
 #include <time.h>
@@ -73,7 +74,6 @@
 #endif
 #include <syslog.h>
 #include <sys/utsname.h>
-#include <config.h>
 #include "gettext.h"
 #include "md5.h"
 #include "protocol.h"


### PR DESCRIPTION
This PR adds a `Dockerfile`.

Demo:

```console
$ hub checkout willglynn/dockerfile
Note: checking out 'willglynn/dockerfile'.
…
HEAD is now at f8962ed Add a Dockerfile
$ docker build -t mactelnet .
Sending build context to Docker daemon    853kB
Step 1/13 : FROM alpine AS builder
…
Successfully tagged mactelnet:latest
$ docker images mactelnet
REPOSITORY          TAG                 IMAGE ID            CREATED                  SIZE
mactelnet           latest              e2aa65d64dd1        Less than a second ago   6.18MB
$ docker run -it --rm --net=host mactelnet mactelnet 4C:5E:0C:9B:AA:DE
Login: admin
Password: 
Connecting to 4C:5E:0C:9B:AA:DE...done

                                                                                                                                                                                


  MMM      MMM       KKK                          TTTTTTTTTTT      KKK
  MMMM    MMMM       KKK                          TTTTTTTTTTT      KKK
  MMM MMMM MMM  III  KKK  KKK  RRRRRR     OOOOOO      TTT     III  KKK  KKK
  MMM  MM  MMM  III  KKKKK     RRR  RRR  OOO  OOO     TTT     III  KKKKK
  MMM      MMM  III  KKK KKK   RRRRRR    OOO  OOO     TTT     III  KKK KKK
  MMM      MMM  III  KKK  KKK  RRR  RRR   OOOOOO      TTT     III  KKK  KKK

  MikroTik RouterOS 6.39.1 (c) 1999-2017       http://www.mikrotik.com/

[?]             Gives the list of available commands
command [?]     Gives help on the command and list of arguments

[Tab]           Completes the command/word. If the input is ambiguous,
                a second [Tab] gives possible options

/               Move up to base level
..              Move up one level
/command        Use command at the base level
[admin@mikrotik] > 
```

This `Dockerfile` uses a [multi-stage build](https://docs.docker.com/develop/develop-images/multistage-build/). The first stage installs a C toolchain, uses it to compile the program's source, and `make install`s to `/build/*`. (The build environment I selected is [Alpine Linux](https://alpinelinux.org), so this PR incorporates #37 by necessity.) The second stage restarts from a baseline Alpine Linux image without any extra packages, installs `gettext` for runtime localization support, and then copies in the `/build/*` output from the first stage to `/usr/`.

The resulting container image is ~6 MB and has no external dependencies.

Ideally this repository would also be configured for [automated builds on Docker Hub](https://docs.docker.com/docker-hub/builds/). That would allow users to say:

```console
$ docker run -it --rm --net=host haakonnessjoen/MAC-Telnet mactelnet 4C:5E:0C:9B:AA:DE
```

…which would download and run e.g. `mactelnet` with no extra fuss.