### PR TITLE
add multi platform docker build as a github actions workflow

### DIFF
--- a/.github/workflows/dockerhub_deploy.yml
+++ b/.github/workflows/dockerhub_deploy.yml
@@ -1,0 +1,30 @@
+name: Docker Deploy
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_HUB_USER }}
+          password: ${{ secrets.DOCKER_HUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ vars.DOCKER_HUB_REPO || 'haakonn/mactelnet' }}:latest


### PR DESCRIPTION
This makes it easy to build cross platform images for amd64 and arm64 and push them to docker hub.  You'd need to add two repository secrets, namely:

    DOCKER_HUB_USER 

to be the docker hub username, and

    DOCER_HUB_TOKEN 

to be a generated api token with sufficient privileges to push images.

I was able to test this in my fork here:

https://github.com/nathanejohnson/MAC-Telnet/actions/runs/8625871441/job/23643151832

