### PR TITLE
Fix build with OpenSSL 1.1.

### DIFF
--- a/src/users.c
+++ b/src/users.c
@@ -211,6 +211,24 @@ struct mt_credentials *find_user(char *username) {
 	return NULL;
 }
 
+#if OPENSSL_VERSION_NUMBER < 0x030000000 // less than 3.0.0
+/*
+ * Filter out colons from the decoded string.
+ * By default, the OPENSSL_buf2hexstr function in OpenSSL 1.1
+ * uses colons as a byte separator, and this cannot be overridden.
+ */
+static void remove_colons(char *s) {
+	const char *p = s;
+	char *q = s;
+	while (*p != '\0') {
+		*q = *p++;
+		q += (*q != ':');
+	}
+
+	*q = '\0';
+}
+#endif
+
 int add_user(const char *username, const char *password) {
 	FILE *rfile;
 	FILE *wfile;
@@ -289,12 +307,27 @@ int add_user(const char *username, const char *password) {
 				continue;
 			}
 			fprintf(wfile, "%s:", username);
+#if OPENSSL_VERSION_NUMBER < 0x030000000 // less than 3.0.0
+			char *output;
+			output = OPENSSL_buf2hexstr(newhash, MT_CRED_HASHLEN);
+			remove_colons(output);
+#else
 			char output[MT_CRED_HASHLEN * 2 + 1];
 			OPENSSL_buf2hexstr_ex(output, sizeof(output), NULL, newhash, MT_CRED_HASHLEN, '\0');
+#endif
 			fputs(output, wfile);
 			fputs(":", wfile);
+#if OPENSSL_VERSION_NUMBER < 0x030000000 // less than 3.0.0
+			OPENSSL_free(output);
+			output = OPENSSL_buf2hexstr(newsalt, MT_CRED_SALTLEN);
+			remove_colons(output);
+#else
 			OPENSSL_buf2hexstr_ex(output, sizeof(output), NULL, newsalt, MT_CRED_SALTLEN, '\0');
+#endif
 			fputs(output, wfile);
+#if OPENSSL_VERSION_NUMBER < 0x030000000 // less than 3.0.0
+			OPENSSL_free(output);
+#endif
 			fputs("\n", wfile);
 			found = 1;
 		} else {
@@ -306,12 +339,27 @@ int add_user(const char *username, const char *password) {
 	if (!found && password != NULL) {
 		// Write username, salt, and hashed password to the file
 		fprintf(wfile, "%s:", username);
+#if OPENSSL_VERSION_NUMBER < 0x030000000 // less than 3.0.0
+		char *output;
+		output = OPENSSL_buf2hexstr(newhash, MT_CRED_HASHLEN);
+		remove_colons(output);
+#else
 		char output[MT_CRED_HASHLEN * 2 + 1];
 		OPENSSL_buf2hexstr_ex(output, sizeof(output), NULL, newhash, MT_CRED_HASHLEN, '\0');
+#endif
 		fputs(output, wfile);
 		fputs(":", wfile);
+#if OPENSSL_VERSION_NUMBER < 0x030000000 // less than 3.0.0
+		OPENSSL_free(output);
+		output = OPENSSL_buf2hexstr(newsalt, MT_CRED_SALTLEN);
+		remove_colons(output);
+#else
 		OPENSSL_buf2hexstr_ex(output, sizeof(output), NULL, newsalt, MT_CRED_SALTLEN, '\0');
+#endif
 		fputs(output, wfile);
+#if OPENSSL_VERSION_NUMBER < 0x030000000 // less than 3.0.0
+		OPENSSL_free(output);
+#endif
 		fputs("\n", wfile);
 	}
 


### PR DESCRIPTION
The OPENSSL_buf2hexstr_ex function was not defined until OpenSSL 3.0.