### PR TITLE
Fix use of undirected broadcast in FreeBSD.

### DIFF
--- a/src/interfaces.c
+++ b/src/interfaces.c
@@ -150,6 +150,9 @@ int net_get_interfaces(struct net_interface **interfaces) {
 	static const struct ifaddrs *ifaddrsp;
 	const struct sockaddr_in *dl_addr;
 	int found = 0;
+#if !defined(__FreeBSD__)
+	long allones_bcast = htonl(INADDR_BROADCAST);
+#endif
 
 	if (getifaddrs(&int_addrs) < 0) {
 		perror("getifaddrs");
@@ -173,8 +176,14 @@ int net_get_interfaces(struct net_interface **interfaces) {
 
 				if (ifaddrsp->ifa_addr->sa_family == AF_INET) {
 					memcpy(interface->ipv4_addr, &dl_addr->sin_addr, IPV4_ALEN);
+#if defined(__FreeBSD__)
+					memcpy(interface->bcast_addr, &((const struct sockaddr_in *)ifaddrsp->ifa_broadaddr)->sin_addr, IPV4_ALEN);
+#else
+					memcpy(interface->bcast_addr, &allones_bcast, IPV4_ALEN);
+#endif
 				} else {
 					memset(interface->ipv4_addr, 0, IPV4_ALEN);
+					memset(interface->bcast_addr, 0, IPV4_ALEN);
 				}
 			}
 #ifdef __linux__
@@ -208,9 +217,12 @@ int net_get_interfaces(struct net_interface **interfaces) {
 		DL_FOREACH(*interfaces, interface) {
 			struct in_addr *addr =
 			  (struct in_addr *)interface->ipv4_addr;
+			struct in_addr *bcast =
+			  (struct in_addr *)interface->bcast_addr;
 
 			printf("Interface %s:\n", interface->name);
 			printf("\tIP: %s\n", inet_ntoa(*addr));
+			printf("\tBCAST: %s\n", inet_ntoa(*bcast));
 			printf("\tMAC: %s\n",
 			  ether_ntoa((struct ether_addr *)interface->mac_addr));
 #ifdef __linux__

--- a/src/interfaces.c
+++ b/src/interfaces.c
@@ -151,7 +151,7 @@ int net_get_interfaces(struct net_interface **interfaces) {
 	const struct sockaddr_in *dl_addr;
 	int found = 0;
 #if !defined(__FreeBSD__)
-	long allones_bcast = htonl(INADDR_BROADCAST);
+	uint32_t allones_bcast = htonl(INADDR_BROADCAST);
 #endif
 
 	if (getifaddrs(&int_addrs) < 0) {

--- a/src/interfaces.h
+++ b/src/interfaces.h
@@ -25,6 +25,7 @@ struct net_interface {
 	char name[256];
 	unsigned char ipv4_addr[IPV4_ALEN];
 	unsigned char mac_addr[ETH_ALEN];
+	unsigned char bcast_addr[IPV4_ALEN];
 
 	/* used by mactelnetd */
 	int socketfd;

--- a/src/mactelnet.c
+++ b/src/mactelnet.c
@@ -126,6 +126,8 @@ unsigned char mt_direction_fromserver = 0;
 
 static unsigned int send_socket;
 
+static unsigned char *bcast_addr;
+
 static int handle_packet(unsigned char *data, int data_len);
 
 static void print_version() {
@@ -168,7 +170,7 @@ static int send_udp(struct mt_packet *packet, int retransmit) {
 		struct sockaddr_in socket_address;
 		socket_address.sin_family = AF_INET;
 		socket_address.sin_port = htons(MT_MACTELNET_PORT);
-		socket_address.sin_addr.s_addr = htonl(INADDR_BROADCAST);
+		memcpy(&(socket_address.sin_addr), bcast_addr, IPV4_ALEN);
 
 		sent_bytes = sendto(send_socket, packet->data, packet->size, 0, (struct sockaddr *)&socket_address,
 							sizeof(socket_address));
@@ -470,6 +472,9 @@ static int find_interface() {
 			continue;
 		}
 
+#if defined(__FreeBSD__)
+		setsockopt(testsocket, IPPROTO_IP, IP_ONESBCAST, &optval, sizeof(optval));
+#endif
 		setsockopt(testsocket, SOL_SOCKET, SO_BROADCAST, &optval, sizeof(optval));
 		setsockopt(testsocket, SOL_SOCKET, SO_REUSEADDR, &optval, sizeof(optval));
 
@@ -488,6 +493,7 @@ static int find_interface() {
 		send_socket = testsocket;
 		memcpy(srcmac, interface->mac_addr, ETH_ALEN);
 		active_interface = interface;
+		bcast_addr = interface->bcast_addr;
 
 		/* Send a SESSIONSTART message with the current device */
 		init_packet(&data, MT_PTYPE_SESSIONSTART, srcmac, dstmac, sessionkey, 0);

--- a/src/mactelnetd.c
+++ b/src/mactelnetd.c
@@ -254,6 +254,12 @@ static void setup_sockets() {
 				perror("SO_BROADCAST");
 				continue;
 			}
+#if defined(__FreeBSD__)
+			if (setsockopt(interface->socketfd, IPPROTO_IP, IP_ONESBCAST, &optval, sizeof(optval)) == -1) {
+				perror("IP_ONESBCAST");
+				continue;
+			}
+#endif
 
 			setsockopt(interface->socketfd, SOL_SOCKET, SO_REUSEADDR, &optval, sizeof(optval));
 
@@ -290,7 +296,7 @@ static int send_udp(const struct mt_connection *conn, const struct mt_packet *pa
 		struct sockaddr_in socket_address;
 		socket_address.sin_family = AF_INET;
 		socket_address.sin_port = htons(conn->srcport);
-		socket_address.sin_addr.s_addr = htonl(INADDR_BROADCAST);
+		memcpy(&(socket_address.sin_addr), &conn->interface->bcast_addr, IPV4_ALEN);
 
 		return sendto(conn->interface->socketfd, packet->data, packet->size, 0, (struct sockaddr *)&socket_address,
 					  sizeof(socket_address));
@@ -315,7 +321,7 @@ static int send_special_udp(struct net_interface *interface, unsigned short port
 		struct sockaddr_in socket_address;
 		socket_address.sin_family = AF_INET;
 		socket_address.sin_port = htons(port);
-		socket_address.sin_addr.s_addr = htonl(INADDR_BROADCAST);
+		memcpy(&(socket_address.sin_addr), &interface->bcast_addr, IPV4_ALEN);
 
 		return sendto(interface->socketfd, packet->data, packet->size, 0, (struct sockaddr *)&socket_address,
 					  sizeof(socket_address));


### PR DESCRIPTION
When you bind to a specific interface's IP in FreeBSD, you cannot use INADDR_BROADCAST as your destination.  While the L3 address will be 255.255.255.255, the L2 address will be that of the gateway.  Instead, use a directed broadcast and set the sockopt IP_ONESBCAST to support turning the directed broadcast into an undirected broadcast on the given interface.

Without this fix, MNDP listening works, but actually using MAC-Telnet to connect to devices does not.