### PR TITLE
Update to the build preparation statement for Debian/ubuntu

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -58,7 +58,7 @@ The latest releases are usually available in the lastest versions of Debian and 
 
 To install the lastest `master` branch *from source*, use the following instructions:
 
-    apt-get install build-essential autopoint automake autoconf libbsd-dev libssl-dev
+    apt-get install build-essential autopoint automake autoconf libbsd-dev libssl-dev gettext
 
 Download source tarball, extract, compile and install:
 


### PR DESCRIPTION
A dependency was missing on the install list, now added.
Verified on Debian12 using Vagrant.

Please reach out if Vagrant file are of any interest to the project.