### PR TITLE
Lookup up MAC addresses in system database.

### DIFF
--- a/doc/macping.1
+++ b/doc/macping.1
@@ -7,7 +7,11 @@ macping \- A tool for pinging other RouterOS or mactelnetd devices
 .SH DESCRIPTION
 This tool enables you to ping other RouterOS or MAC-Telnetd enabled
 devices. You can ping either a hostname or a MAC address.
-If specified, the hostname (identity) will be looked up via MNDP discovery.
+If specified, the hostname (identity) will be looked up via
+.BR ether_hostton(3)
+(typically in
+.BR ethers(5) )
+or if that fails, MNDP discovery.
 .SH OPTIONS
 These programs follow the usual GNU command line syntax.
 A summary of options is included below.

--- a/doc/mactelnet.1
+++ b/doc/mactelnet.1
@@ -7,7 +7,11 @@ mactelnet \- A tool for telneting via MAC addresses
 .SH DESCRIPTION
 This tool enables you to telnet other RouterOS or MAC-Telnetd enabled
 devices. You can connect to either a hostname or a MAC address.
-If specified, the hostname (identity) will be looked up via MNDP discovery.
+If specified, the hostname (identity) will be looked up via
+.BR ether_hostton(3)
+(typically in
+.BR ethers(5) )
+or if that fails, MNDP discovery.
 .SH OPTIONS
 These programs follow the usual GNU command line syntax.
 A summary of options is included below.

--- a/src/protocol.c
+++ b/src/protocol.c
@@ -533,6 +533,9 @@ int query_mndp_or_mac(char *address, unsigned char *dstmac, int verbose) {
 	}
 
 	if (colons != 5) {
+		if (ether_hostton(address, (struct ether_addr*)dstmac) == 0) {
+			return 1;
+		}
 		/*
 		 * Not a valid mac-address.
 		 * Search for Router by identity name, using MNDP


### PR DESCRIPTION
When a hostname is provided, look it up in the system MAC address database via ether_hostton, which usually reads /etc/ethers. Fall back on MNDP only if the it fails.