### PR TITLE
set SO_REUSEPORT for MNDP discovery to avoid blocking other MNDP listeners

### DIFF
--- a/src/mndp.c
+++ b/src/mndp.c
@@ -89,6 +89,9 @@ int mndp(int timeout, int batch_mode) {
 
 	int optval = 1;
 	setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, &optval, sizeof(optval));
+#ifdef SO_REUSEPORT
+	setsockopt(sock, SOL_SOCKET, SO_REUSEPORT, &optval, sizeof(optval));
+#endif
 
 	/* Bind to specified address/port */
 	if (bind(sock, (struct sockaddr *)&si_me, sizeof(si_me)) == -1) {


### PR DESCRIPTION
Fix for #102 