### PR TITLE
add homebrew instructions for macos

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -87,7 +87,12 @@ Download source tarball, extract, compile and install:
 
 ### Mac OS X
 
-Download source tarball and extract:
+You can install directly using Homebrew:
+
+    brew trust gregsadetsky/mactelnet
+    brew install gregsadetsky/mactelnet/mactelnet
+
+Alternatively, you can download source tarball and extract:
 
     wget http://github.com/haakonnessjoen/MAC-Telnet/tarball/master -O mactelnet.tar.gz
     tar zxvf mactelnet.tar.gz


### PR DESCRIPTION
hey - thanks for the amazing project!

I packaged it as a homebrew tap to make it a two-line install on macOS - hence this PR on the readme:

```bash
brew trust gregsadetsky/mactelnet
brew install gregsadetsky/mactelnet/mactelnet
```

you can see the [source tap repo here](https://github.com/gregsadetsky/homebrew-mactelnet).

it builds your tagged releases and serves prebuilt "bottles" (ie binaries), with no changes to your code or build. CI also produces a linux "bottle", though I've only tested on macOS (on Apple Silicon), so I only updated macOS installation instructions in the readme.

totally understand if you'd rather keep the current install instructions - the tap above will track your release tags automatically either way. 

thanks again for the great tool! cheers